### PR TITLE
チャットスペースのグループ編集の設定

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -9,7 +9,7 @@
           - @group.users.each do |member_name|
             = member_name.name
       .header__edit
-        = link_to edit_group_path(current_user), class: "editbtn" do 
+        = link_to edit_group_path(@group), class: "editbtn" do 
           %p.header__editbtn Edit
     .message-list
       .messagespace

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root "groups#index"
+  root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]


### PR DESCRIPTION
# What
チャットグループで各グループの編集ページに移動できるようにした。

# Why
各グループのグループ名やメンバーの編集をできるようにするため。